### PR TITLE
Unfreeze the game after the last move by player

### DIFF
--- a/game_engine.hpp
+++ b/game_engine.hpp
@@ -24,10 +24,6 @@ public:
 
     CONSTEXPR game_engine& update(KeyboardInput input)
     {
-        if (moves_ <= 0) {
-            return *this;
-        }
-
         bool board_updating = falldown() | generate();
 
         if (board_updating) {
@@ -237,6 +233,9 @@ private:
                 auto selected = find_if([](const candy& c){ return c.state.selected; });
 
                 if (selected) {
+                    if (moves_ <= 0) {
+                        break;
+                    }
                     auto [selected_x, selected_y] = selected.value();
 
                     if (abs(selected_x - cursor_x) <=1 && abs(selected_y - cursor_y) <= 1) {


### PR DESCRIPTION
Every valid move, including the last valid move, shall cause candies
matching with animation, fall-downs and further cascading matching and
fall-downs. The game however freezes after the last move is consumed
because the game reaction is conditioned by non-zero remaining moves.

The Suggested Solution is to condition by remaining moves to play only
candy swapping itself, allowing both the automatic game reactions and
user's cursor movements/selections to make the game responsive even
though player doesn't earn further score points.