### PR TITLE
[issue#4] Make include files self-contained

### DIFF
--- a/board.hpp
+++ b/board.hpp
@@ -5,6 +5,7 @@
 #ifndef META_CRUSH_SAGA_BOARD_HPP
 #define META_CRUSH_SAGA_BOARD_HPP
 
+#include <array>
 #include <iostream>
 #include <utility>
 

--- a/constexpr_string_view.hpp
+++ b/constexpr_string_view.hpp
@@ -1,6 +1,12 @@
 #ifndef META_CRUSH_SAGA_CONSTEXPR_STRING_VIEW_HPP
 #define META_CRUSH_SAGA_CONSTEXPR_STRING_VIEW_HPP
 
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+
+#include "constexpr_string.hpp"
+
 class constexpr_string_view
 {
 public:

--- a/random.hpp
+++ b/random.hpp
@@ -1,6 +1,7 @@
 #ifndef META_CRUSH_SAGA_RANDOM_HPP
 #define META_CRUSH_SAGA_RANDOM_HPP
 
+#include <cstdint>
 
 class random_generator
 {
@@ -20,4 +21,4 @@ public:
     std::uint16_t prev_;
 };
 
-#endif //META_CRUSH_SAGA_RANDOM_HPP  
+#endif //META_CRUSH_SAGA_RANDOM_HPP


### PR DESCRIPTION
Issue#4 points out that some include files use identifiers that are
not declared within the file relying on that appropriate definition
files are included in source before including the current include
file.

Suggested solution: add necessary definition files to make include
files self-contained in accordance with ACCU's Best Practice
https://accu.org/index.php/journals/1995